### PR TITLE
README: use `-create` instead of `-applet`

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ opensource tools such as "gp.jar" and "gpj.jar" you can do it like this:
 
 ```
  user@host:~$ java -jar gp.jar \
-        -applet D2760000850101 \
+        -create D2760000850101 \
         -params 100BD101075402656E54657374 \
         -install build/javacard/javacard-ndef-tiny.cap
  (Install tiny variant with static text "Test")
@@ -124,7 +124,7 @@ opensource tools such as "gp.jar" and "gpj.jar" you can do it like this:
 
 ```
  user@host:~$ java -jar gp.jar \
-        -applet D2760000850101 \
+        -create D2760000850101 \
         -params 3FABCDABCD \
         -install build/javacard/javacard-ndef-stub.cap
  (Install stub variant using backend in app ABCDABCD service 0x3F)
@@ -132,7 +132,7 @@ opensource tools such as "gp.jar" and "gpj.jar" you can do it like this:
 
 ```
  user@host:~$ java -jar gp.jar \
-        -applet D2760000850101 \
+        -create D2760000850101 \
         -params 810200F182020800 \
         -install build/javacard/javacard-ndef-full.cap
  (Install full variant as a write-once tag with 2048 bytes of memory)


### PR DESCRIPTION
The README had incorrect instructions for the installation of the applet, using the argument `-applet` instead of `-create`.

@martinpaljak [notes][1] the difference between the two:

> `--create` specifies the instance AID and that needs to be the NFC forum defined one.
> ...
> `--applet`, when used with `--install` selects a module from multi-applet package (or the module after a standalone `--load`).

This change simply changes the instances of `-applet` to `-create` to ensure that the installed applet is given the correct AID.

[1]: https://github.com/OpenJavaCard/openjavacard-ndef/issues/4#issuecomment-573691490